### PR TITLE
fixjfm.sty: Fix a bug in math mode

### DIFF
--- a/fixjfm.sty
+++ b/fixjfm.sty
@@ -104,7 +104,7 @@
   \else
     \def\DeclareFixJFMCJKTextFontCommand#1#2{%
       \DeclareRobustCommand#1[1]{%
-        \relax\ifmmode\nfss@text\fi{#2\fixjfmspacing##1}\fixjfmspacing}}%
+        \relax\ifmmode\expandafter\nfss@text\fi{#2\fixjfmspacing##1}\fixjfmspacing}}%
     \def\UseFixJFMCJKTextFontCommands{%
       \DeclareFixJFMCJKTextFontCommand\textmc{\mcfamily}%
       \DeclareFixJFMCJKTextFontCommand\textgt{\gtfamily}}%


### PR DESCRIPTION
Thank you very much for providing the package! (Today I released a new version of jsclasses to improve compatibility with fixjfm package: texjporg/jsclasses#59.)

Current fixjfm.sty causes an error when \textmc or \textgt is used in math mode:

~~~~ tex
\documentclass{article}
\usepackage{fixjfm}
\begin{document}
$a\textgt{中}$
\end{document}
~~~~
~~~~
LaTeX Error: Command \gtfamily invalid in math mode.
~~~~

My patch will fix the issue.