### PR TITLE
Allow \Declare...CJKTextFontCommand after preamble

### DIFF
--- a/fixjfm.sty
+++ b/fixjfm.sty
@@ -116,8 +116,6 @@
     \def\UseStandardCJKTextFontCommands{%
       \DeclareStandardCJKTextFontCommand\textmc{\mcfamily}%
       \DeclareStandardCJKTextFontCommand\textgt{\gtfamily}}%
-    \@onlypreamble\DeclareFixJFMCJKTextFontCommand
-    \@onlypreamble\DeclareStandardCJKTextFontCommand
     \UseFixJFMCJKTextFontCommands
   \fi
 


### PR DESCRIPTION
Thanks for early reply in #1. Sorry, the latest master still causes an error with

\UseStandardCJKTextFontCommands

after \begin{document}. `\Use...CJKTextFontCommands` calls `\Declare...CJKTextFontCommand`, so the declaration command should also be enabled after \begin{document}.

By the way, when two `\@onlypreamble`s are removed, the following usage is also allowed, which I think much useful besides the documented local usage.

~~~~ tex
\documentclass{article}
\usepackage{fixjfm}
\begin{document}

\UseFixJFMCJKTextFontCommands
小）\textgt{（小）}（小）\textgt{（小）}（小\par

\UseStandardCJKTextFontCommands
小\textgt{\Large 大}小\textgt{\Large 大}小

\UseFixJFMCJKTextFontCommands
小）\textgt{（小）}（小）\textgt{（小）}（小\par

\end{document}
~~~~