### PR TITLE
\xspcode, \inhibitxspcode and \(no)auto(x)spacing

### DIFF
--- a/fixjfm.sty
+++ b/fixjfm.sty
@@ -18,6 +18,8 @@
 
 \catcode`\@=11\relax
 
+% common utilities
+
 \def\fixjfm@ifprimitive#1{%
   \begingroup
     \edef\fixjfm@temp@meaning{\meaning#1}%
@@ -35,9 +37,43 @@
 
 \def\fixjfm@empty{}
 
+\begingroup
+  \let\CATCODE=\catcode
+  \let\RELAX=\relax
+  \let\GDEF=\gdef
+  \let\ENDGROUP=\endgroup
+  \CATCODE`\k=12\RELAX
+  \CATCODE`\a=12\RELAX
+  \CATCODE`\n=12\RELAX
+  \CATCODE`\j=12\RELAX
+  \CATCODE`\i=12\RELAX
+  \CATCODE`\c=12\RELAX
+  \CATCODE`\h=12\RELAX
+  \CATCODE`\r=12\RELAX
+  \CATCODE`\t=12\RELAX
+  \CATCODE`\e=12\RELAX
+  \GDEF\FIXJFM@KANJICHARACTER{kanji character }%
+\ENDGROUP
+
+\def\fixjfm@get@inhibitxspcode#1{%
+  \expandafter\expandafter\expandafter\fixjfm@@get@inhibitxspcode
+  \expandafter\meaning\expandafter#1\FIXJFM@KANJICHARACTER
+  \relax\fixjfm@nil}
+\expandafter\def\expandafter\fixjfm@@get@inhibitxspcode
+  \expandafter#\expandafter1\FIXJFM@KANJICHARACTER#2#3\fixjfm@nil{%
+  \count2=-1\relax
+  \def\fixjfm@temp@tokens{#1}%
+  \ifx\fixjfm@temp@tokens\fixjfm@empty
+    \count2=\inhibitxspcode`#2\relax
+  \fi}
+
+% \leavevmode
+
 \fixjfm@ifprimitive\quitvmode
   \let\leavevmode=\quitvmode
 \fi
+
+% \fixjfmspacing
 
 \def\fixjfmspacing{\FixJFMSpacing}
 
@@ -63,7 +99,13 @@
       \edef\fixjfm@sp@temp@tokens{\fixjfm@sp@temp@token}%
       \expandafter\fixjfm@@fixspacing\fixjfm@sp@temp@tokens\relax\fixjfm@sp@nil
       \ifnum\count0>-1\relax
-        \ifnum\count0<256\relax\hskip\xkanjiskip\else\hskip\kanjiskip\fi
+        \ifnum\count0<256\relax
+          \ifnum\xspcode\count0>1\relax \ifnum\count2>1\relax
+            \hskip\xkanjiskip
+          \fi \fi
+        \else
+          \hskip\kanjiskip
+        \fi
         \setbox0=\hbox{%
           \inhibitglue\char\count0\relax\fixjfm@sp@temp@token\inhibitglue}%
         \setbox2=\hbox{%
@@ -74,6 +116,7 @@
       \fi
     \endgroup}%
   \long\def\fixjfm@@fixspacing#1#2\fixjfm@sp@nil{%
+    \count2=1\relax
     \ifcat#1\fixjfm@kanji
     \else
       \ifcat#1\fixjfm@kana
@@ -81,8 +124,12 @@
         \ifcat#1\fixjfm@other
         \else
           \count0=-1\relax
+          \count2=0\relax
         \fi
       \fi
+    \fi
+    \ifnum\count2>0\relax
+      \fixjfm@get@inhibitxspcode#1\relax
     \fi}%
   \def\SetFixJFMSpacingStretch#1{\def\fixjfm@temp@hskip@stretch{#1}}%
   \def\SetFixJFMSpacingShrink#1{\def\fixjfm@temp@hskip@shrink{#1}}%
@@ -120,11 +167,15 @@
     \UseFixJFMCJKTextFontCommands
   \fi
 
+% \inhibitglue
+
 \fixjfm@ifprimitive\protected
   \protected\def\<{\ifvmode\leavevmode\fi\inhibitglue}%
 \else
   \def\<{\inhibitglue}%
 \fi
+
+% \fixjfmparindent
 
 \def\fixjfmparindent{\FixJFMParindent}
 
@@ -139,39 +190,11 @@
   \fi
 \endgroup
 
-\begingroup
-  \let\CATCODE=\catcode
-  \let\RELAX=\relax
-  \let\GDEF=\gdef
-  \let\ENDGROUP=\endgroup
-  \CATCODE`\k=12\RELAX
-  \CATCODE`\a=12\RELAX
-  \CATCODE`\n=12\RELAX
-  \CATCODE`\j=12\RELAX
-  \CATCODE`\i=12\RELAX
-  \CATCODE`\c=12\RELAX
-  \CATCODE`\h=12\RELAX
-  \CATCODE`\r=12\RELAX
-  \CATCODE`\t=12\RELAX
-  \CATCODE`\e=12\RELAX
-  \GDEF\FIXJFM@KANJICHARACTER{kanji character }%
-\ENDGROUP
-
 \def\FixJFMParindent{\futurelet\fixjfm@pi@temp@token\fixjfm@fixparindent}
 
 \def\fixjfm@fixparindent{%
-  \expandafter\expandafter\expandafter\fixjfm@@fixparindent
-    \expandafter\meaning\expandafter\fixjfm@pi@temp@token
-    \FIXJFM@KANJICHARACTER\relax\fixjfm@pi@nil}
-
-\expandafter\def\expandafter\fixjfm@@fixparindent
-  \expandafter#\expandafter1\FIXJFM@KANJICHARACTER#2#3\fixjfm@pi@nil{%
-    \def\fixjfm@pi@temp@tokens{#1}%
-    \ifx\fixjfm@pi@temp@tokens\fixjfm@empty
-      \ifnum\the\inhibitxspcode`#2=2\relax
-        \inhibitglue
-      \fi
-    \fi}
+  \fixjfm@get@inhibitxspcode\fixjfm@pi@temp@token
+  \ifnum\count2=2\relax\inhibitglue\fi}
 
 \begingroup\expandafter\expandafter\expandafter\endgroup
   \expandafter\ifx\csname PushPostHook\endcsname\relax % everyhook.sty

--- a/fixjfm.sty
+++ b/fixjfm.sty
@@ -92,6 +92,33 @@
     \xdef\fixjfm@kana{\kansuji2}%
     \xdef\fixjfm@other{\kansuji3}%
   \endgroup
+  \newif\iffixjfm@sp@status@
+  \def\fixjfm@ifautospacing{%
+    \fixjfm@sp@status@false
+    \begingroup
+      \kanjiskip10pt
+      % current setting
+      \setbox0=\hbox{\fixjfm@kanji\fixjfm@kanji\fixjfm@kanji}\dimen4\wd0
+      % force \noautospacing
+      \noautospacing
+      \setbox0=\hbox{\fixjfm@kanji\fixjfm@kanji\fixjfm@kanji}\dimen2\wd0
+      \expandafter
+    \endgroup
+    \ifdim\dimen4>\dimen2\relax \fixjfm@sp@status@true \fi}
+  \def\fixjfm@ifautoxspacing{%
+    \fixjfm@sp@status@false
+    \begingroup
+      \xspcode`A=3\relax
+      \inhibitxspcode`漢=3\relax
+      \xkanjiskip20pt
+      % current setting
+      \setbox0=\hbox{\fixjfm@kanji A\fixjfm@kanji}\dimen4\wd0
+      % force \noautoxspacing
+      \noautoxspacing
+      \setbox0=\hbox{\fixjfm@kanji A\fixjfm@kanji}\dimen2\wd0
+      \expandafter
+    \endgroup
+    \ifdim\dimen4>\dimen2\relax \fixjfm@sp@status@true \fi}
   \def\FixJFMSpacing{\futurelet\fixjfm@sp@temp@token\fixjfm@fixspacing}%
   \def\fixjfm@fixspacing{%
     \begingroup
@@ -101,10 +128,10 @@
       \ifnum\count0>-1\relax
         \ifnum\count0<256\relax
           \ifnum\xspcode\count0>1\relax \ifnum\count2>1\relax
-            \hskip\xkanjiskip
+            \fixjfm@ifautoxspacing \iffixjfm@sp@status@\hskip\xkanjiskip\fi
           \fi \fi
         \else
-          \hskip\kanjiskip
+          \fixjfm@ifautospacing \iffixjfm@sp@status@\hskip\kanjiskip\fi
         \fi
         \setbox0=\hbox{%
           \inhibitglue\char\count0\relax\fixjfm@sp@temp@token\inhibitglue}%

--- a/fixjfm.sty
+++ b/fixjfm.sty
@@ -109,7 +109,7 @@
     \fixjfm@sp@status@false
     \begingroup
       \xspcode`A=3\relax
-      \inhibitxspcode`漢=3\relax
+      \inhibitxspcode\sjis"8ABF=3\relax % U+6F22: Kanji Han
       \xkanjiskip20pt
       % current setting
       \setbox0=\hbox{\fixjfm@kanji A\fixjfm@kanji}\dimen4\wd0


### PR DESCRIPTION
As I mentioned in #3, the current code does not consider about `\xspcode` and `\inhibitxspcode`, so, for example (\textgt{漢字}) became wrong.

I wrote another test code to support `\xspcode`, `\inhibitxspcode` and `\(no)auto(x)spacing`. It seems there is no problem with my [test case](https://gist.github.com/aminophen/cfed6116dd0a3475b6aef36ba673f713).