### PR TITLE
Add \FixJFMSpacingFullExpand

### DIFF
--- a/fixjfm.sty
+++ b/fixjfm.sty
@@ -75,7 +75,8 @@
 
 % \fixjfmspacing
 
-\def\fixjfmspacing{\FixJFMSpacing}
+% \def\fixjfmspacing{\FixJFMSpacing}
+\def\fixjfmspacing{\expandafter\FixJFMSpacingFullExpand\romannumeral-`\Q}
 
 \newif\iffixjfm@lastnodechar@available@
 
@@ -124,6 +125,7 @@
       \fixjfm@sp@status@true
     \fi}%
   \def\FixJFMSpacing{\futurelet\fixjfm@sp@temp@token\fixjfm@fixspacing}%
+  \def\FixJFMSpacingFullExpand{\expandafter\futurelet\expandafter\fixjfm@sp@temp@token\expandafter\fixjfm@fixspacing\romannumeral-`\Q}%
   \def\fixjfm@fixspacing{%
     \begingroup
       \count0=\lastnodechar


### PR DESCRIPTION
Thank you for this nice package.

\fixjfmspacing gets an error if it is placed before some macros.

```tex
\RequirePackage{fixjfm}
\documentclass[uplatex]{jsarticle}
\begin{document}
猫\fixjfmspacing
\end{document}
```
The above example gets the following error:


     Argument of \fixjfm@sp@temp@token has an extra }.
     <inserted text> 
                     \par 
     l.5 \end
             {document}


This is because \fixjfmspacing is placed before '\end{document}'.

My patch will fix this issue.
